### PR TITLE
Fix: Change spelling of environnement to environment in various files.

### DIFF
--- a/examples/Commerical/basic_mgt_spoke/variables.tf
+++ b/examples/Commerical/basic_mgt_spoke/variables.tf
@@ -10,7 +10,7 @@ variable "environment" {
 }
 
 variable "deploy_environment" {
-  description = "Name of the workload's environnement (dev, test, prod, etc). This will be used to name the resources deployed by this module. default is 'dev'"
+  description = "Name of the workload's environment (dev, test, prod, etc). This will be used to name the resources deployed by this module. default is 'dev'"
   type        = string
 }
 

--- a/examples/Government/basic_mgt_spoke/variables.tf
+++ b/examples/Government/basic_mgt_spoke/variables.tf
@@ -10,7 +10,7 @@ variable "environment" {
 }
 
 variable "deploy_environment" {
-  description = "Name of the workload's environnement (dev, test, prod, etc). This will be used to name the resources deployed by this module. default is 'dev'"
+  description = "Name of the workload's environment (dev, test, prod, etc). This will be used to name the resources deployed by this module. default is 'dev'"
   type        = string
 }
 

--- a/modules/private_endpoints/variables.tf
+++ b/modules/private_endpoints/variables.tf
@@ -16,7 +16,7 @@ variable "environment" {
 }
 
 variable "deploy_environment" {
-  description = "Name of the workload's environnement"
+  description = "Name of the workload's environment"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "environment" {
 }
 
 variable "deploy_environment" {
-  description = "Name of the workload's environnement"
+  description = "Name of the workload's environment"
   type        = string
 }
 


### PR DESCRIPTION
These changes fix a spelling mistake made within various files within the project repository.

In the following files, instances of a misspelled word - `environnement` - has been corrected to `environment`, [following the Merrier-Webster spelling of the word.](https://www.merriam-webster.com/dictionary/environment):
* `examples/Government/basic_mgt_spoke/variables.tf`
* `examples/Government/basic_mgt_spoke/variables.tf`
* `modules/private_endpoints/variables.tf`
* `variables.tf`



